### PR TITLE
Reattempt connecting to rabbit several times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,36 @@
 language: rust
-
 rust:
-  - stable
-
+- stable
 cache: cargo
-
 script:
-  - cargo build --all
-  - cargo test -- --test-threads=1
-  - ./bin/smoketest.sh
-
+- cargo build --all
+- cargo test -- --test-threads=1
+- "./bin/smoketest.sh"
 matrix:
   include:
-    - name: "With Elasticsearch 6xx"
-      env: ES_IMAGE=elasticsearch:2.4.6
-    - name: "With Elasticsearch 2xx"
-      env: ES_IMAGE=docker.elastic.co/elasticsearch/elasticsearch:6.5.0
-
+  - name: With Elasticsearch 6xx
+    env: ES_IMAGE=elasticsearch:2.4.6
+  - name: With Elasticsearch 2xx
+    env: ES_IMAGE=docker.elastic.co/elasticsearch/elasticsearch:6.5.0
 services:
-  - docker
-
+- docker
 before_script:
-  - ./bin/setup-and-wait.sh
+- "./bin/setup-and-wait.sh"
+deploy:
+- provider: releases
+  api_key:
+    secure: GITHUB_TOKEN
+  file: target/x86_64-unknown-linux-musl/release/rmqfwd
+  skip_cleanup: true
+  on:
+    tags: true
+- provider: cargo
+  token: CARGO_TOKEN
+  on:
+    tags: true
+before_deploy:
+- "./bin/build.sh"
+env:
+  global:
+  - secure: GnAbB3WK0bxR5SeXOZDJZSbs06RB87FGdBDt0G696qyE+7piGFUKQAxyujq9b0T5aefRw8fJbfx1tEG6Kc2ro8V3CwxUOjxamr0myueZf9LnxsczSsWXpF0Y7W2c58NVPoXtl1PIcf5nye748XGRLMFDD5WZ7tu0c+I+6260cC2nW1GuZIkpY1SfjhHBFMOi8o+6aKigjJK01iIO0fOD+/bItRrbYRuQ8yeA4MiD9KhqcTQlj9H1X+3dnhoS3fHG9ckc0cF6r9KLWzA1efNcWhWwFO0mIW2flN/yBj/gX+RsO+g9sSZsrlzYpX/u26EGkCrrbkmGxvyptwK/wHJYPXIaNYv4jR7owuMkY/+bV3Mw7RNopgkgp5ffpaCyyId1ojhavGzfRqxabphH2YDe/9WgGgqWg46gH0SXyqOOGivYzZiIKnQh7w655qMGRe/UBQ+Z1hzz+deUiW6iSaPK9+ygFsIfAt4UfFeJkvsmNmZFRkFwO8nWDG/73Qh6xQtb61U0w52Z0fQLUwlWTPYLssc+PJoBs9JxuxzaL9drcvGtHaghJB7ct00aFhkgFbhJj1eUUuocRsS/DqF0LEPMqzBKxpUXY6O4cfVqMaoAcvgI8uU0mbzwFA1ZMo2pQ4WHYBkRfYp3T6iEhag6tK5ACIhihFRr1ngnFPaNdWGu+gQ=
+  - secure: wJRhJPMhWoNciF/vFABc4EARE9w3f0p7UWYx35UHLqj58tfDHXetm/hyiL6TgMYSW5Tub1X4mbqRFFMoojO1TkWHMJC3QHQlGrGtOd3SbRBBZ27B78dXt10KtPZDz1kl0nNhuVMLvgLOKmbA9HqnWeyWI5MZAtX+Vv5r8r9hBcU/DVeCK/vd08iKxWmb3Q4Sbf7HXWFKv54b+j6MfraGa0jzH8I1aIbIYqSFFzwNsClgkttwN8FXnd1t93VqiTYi57L6ep/tS+yAg9KDTHScTLd5AYaTDV5aHMC1eMsjrS5pi2PiOVKD8oSoe1EIm4+phviSbfRYBvMAZEnA/0Clc6Wm79/2E/+yJm4xXwW//0x1g9tPR2mtisUjG3qmT48aqRCkOq+2wYft/7n2+EqjwQ8fwnYElIcyy5lsVJEQcDnHCuYT145234eXLPwCEzJPfi7j9pgR0QceyxpR2W0W6tzC+4erpmOjAhvGwBEbJ8egXa1p8OyP8IWumc+Nwi1aiXI6hBOezwqz03dRW33pwsNBnOurLr6DsRFEpqU1RyJRitNy+Nniz944Bqpg/f8oPXuBsVyiYenNUqLv8GfevoLiwKLTF1isdT8nRT7uJBPz0Wnsw+KNMRBnVqkwjtfVmDduYtpbmleeqGnHne+bsvaRYtMjjPgvdx7xMjw+naM=

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Once persisted, messages can be filtered, exported, and re-published.
 ## Usage
 
 ```
-rmqfwd 0.1.0
-
 USAGE:
     rmqfwd [SUBCOMMAND]
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+
+alias rust-musl-builder='docker run --rm -it -v "$(pwd)":/home/rust/src ekidd/rust-musl-builder'
+rust-musl-builder cargo build --release --target x86_64-unknown-linux-musl

--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
       git
       gnused
       coreutils
-      gitAndTools.hub
+      travis
     ];
 
     RUST_LOG="warn";

--- a/k8s/es/kibana.yml
+++ b/k8s/es/kibana.yml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: kibana
+  labels:
+    app: kibana
+spec:
+  # modify replicas according to your case
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kibana
+  template:
+    metadata:
+      labels:
+        app: kibana
+    spec:
+      containers:
+      - name: kibana 
+        image: docker.elastic.co/kibana/kibana-oss:6.2.4
+        ports:
+        - containerPort: 5601
+        volumeMounts:
+        - name: config
+          mountPath: /usr/share/kibana/config
+          readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: kibana-config
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana-lb
+  labels:
+    app: kibana
+spec:
+  selector:
+    app: kibana
+  ports:
+  - name: http
+    port: 5601
+  type: LoadBalancer
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kibana-config
+data:
+  kibana.yml: |
+    ---
+    server.name: kibana
+    server.host: "0"
+    elasticsearch.url: "http://elasticsearch-0.es.default.svc.cluster.local:9200"

--- a/k8s/es/load-balancer.yml
+++ b/k8s/es/load-balancer.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: es-lb
+  labels:
+    service: elasticsearch
+spec:
+  selector:
+    service: elasticsearch
+  ports:
+  - name: http
+    port: 9200
+  type: LoadBalancer

--- a/k8s/es/service.yml
+++ b/k8s/es/service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: es
+  labels:
+    service: elasticsearch
+spec:
+  selector:
+    service: elasticsearch
+  ports:
+  - name: transport
+    port: 9300
+    protocol: TCP
+  clusterIP: None

--- a/k8s/es/statefulset.yml
+++ b/k8s/es/statefulset.yml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+  labels:
+    service: elasticsearch
+spec:
+  serviceName: es
+  # NOTE: This is number of nodes that we want to run
+  # you may update this
+  replicas: 3
+  selector:
+    matchLabels:
+      service: elasticsearch
+  template:
+    metadata:
+      labels:
+        service: elasticsearch
+    spec:
+      terminationGracePeriodSeconds: 300
+      initContainers:
+      # NOTE:
+      # This is to fix the permission on the volume
+      # By default elasticsearch container is not run as
+      # non root user.
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_notes_for_production_use_and_defaults
+      - name: fix-the-volume-permission
+        image: busybox
+        command:
+        - sh
+        - -c
+        - chown -R 1000:1000 /usr/share/elasticsearch/data
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/elasticsearch/data
+      # NOTE:
+      # To increase the default vm.max_map_count to 262144
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-prod-mode
+      - name: increase-the-vm-max-map-count
+        image: busybox
+        command:
+        - sysctl
+        - -w
+        - vm.max_map_count=262144
+        securityContext:
+          privileged: true
+      # To increase the ulimit
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_notes_for_production_use_and_defaults
+      - name: increase-the-ulimit
+        image: busybox
+        command:
+        - sh
+        - -c
+        - ulimit -n 65536
+        securityContext:
+          privileged: true
+      containers:
+      - name: elasticsearch
+        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+        ports:
+        - containerPort: 9200
+          name: http
+        - containerPort: 9300
+          name: tcp
+        # NOTE: you can increase this resources
+        # resources:
+        #  requests:
+        #    memory: 8Gi
+        #  limits:
+        #    memory: 16Gi
+        env:
+          # NOTE: the cluster name; update this
+          - name: cluster.name
+            value: elasticsearch-cluster
+          - name: node.name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          # NOTE: This will tell the elasticsearch node where to connect to other nodes to form a cluster
+          - name: discovery.zen.ping.unicast.hosts
+            value: "elasticsearch-0.es.default.svc.cluster.local,elasticsearch-1.es.default.svc.cluster.local,elasticsearch-2.es.default.svc.cluster.local"
+          # NOTE: You can increase the heap size
+          - name: ES_JAVA_OPTS
+            value: -Xms1g -Xmx1g
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/elasticsearch/data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: fast
+      # NOTE: You can increase the storage size
+      resources:
+        requests:
+          storage: 1Gi
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast
+provisioner: k8s.io/minikube-hostpath
+parameters:
+  type: pd-ssd

--- a/k8s/rmq/Dockerfile
+++ b/k8s/rmq/Dockerfile
@@ -1,0 +1,16 @@
+FROM rabbitmq:3.6.12-alpine
+
+RUN rabbitmq-plugins enable --offline rabbitmq_management
+
+ENV RABBITMQ_ERLANG_COOKIE changeThis
+
+# Add files.
+COPY ./cmd.sh /
+COPY ./rabbitmq.config /etc/rabbitmq/rabbitmq.config
+
+# Define default command.
+RUN ["chmod", "+x", "/cmd.sh"]
+CMD ["/cmd.sh"]
+
+# default ports + management plugin ports
+EXPOSE 4369 5671 5672 25672 15671 15672

--- a/k8s/rmq/cmd.sh
+++ b/k8s/rmq/cmd.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+ulimit -n 65536
+
+chown -R rabbitmq:rabbitmq /var/lib/rabbitmq
+
+# This is needed for statefulset service name resolution - needed for short name resolution
+if [ -n "$RABBITMQ_SERVICE_DOMAIN" ]; then
+    echo "search $RABBITMQ_SERVICE_DOMAIN" >> /etc/resolv.conf
+fi
+
+is_clustered="/var/lib/rabbitmq/is_clustered"
+
+host=`hostname`
+
+join_cluster () {
+    if [ -e $is_clustered ]; then
+        echo "Already clustered with $CLUSTER_WITH"
+    else
+        # Don't cluster with self or if already clustered
+        if ! [[ $CLUSTER_WITH =~ $host ]]; then
+            rabbitmq-server -detached
+            rabbitmqctl stop_app
+            rabbitmqctl join_cluster rabbit@$CLUSTER_WITH
+            rabbitmqctl start_app
+
+            # mark that this node is clustered
+            mkdir $is_clustered
+            # stopping because it we started it later in attached mode
+            rabbitmqctl stop
+            sleep 5
+        fi
+    fi
+}
+
+create_vhost() {
+    rabbitmq-server -detached
+    until rabbitmqctl node_health_check; do echo "Waiting to start..." && sleep 1; done;
+
+    USER_EXISTS=`rabbitmqctl list_users | { grep $RABBITMQ_USERNAME || true; }`
+
+    # create user only if it doesn't exist
+    if [ -z "$USER_EXISTS" ]; then
+        rabbitmqctl add_user $RABBITMQ_USERNAME $RABBITMQ_PASSWORD
+        rabbitmqctl add_vhost $RABBITMQ_VHOST
+        rabbitmqctl set_permissions -p $RABBITMQ_VHOST $RABBITMQ_USERNAME ".*" ".*" ".*"
+        rabbitmqctl set_policy -p $RABBITMQ_VHOST ha-all "" '{"ha-mode":"all","ha-sync-mode":"automatic"}'
+    fi
+    # stopping because it we started it later in attached mode
+    rabbitmqctl stop
+    sleep 5
+}
+
+if [ -n "$CLUSTERED" ] && [ -n "$CLUSTER_WITH" ]; then
+    join_cluster
+fi
+
+if [ -n "$RABBITMQ_USERNAME" -a -n "$RABBITMQ_PASSWORD" -a -n "$RABBITMQ_VHOST" ]; then
+    create_vhost
+fi
+
+rabbitmq-server $RABBITMQ_SERVER_PARAMS

--- a/k8s/rmq/rabbitmq.config
+++ b/k8s/rmq/rabbitmq.config
@@ -1,0 +1,14 @@
+[
+    { rabbit, [
+            { trace_vhosts, [<<"/">>] },
+            { loopback_users, [ ] },
+            { tcp_listeners, [ 5672 ] },
+            { ssl_listeners, [ ] },
+            { hipe_compile, false },
+            { cluster_partition_handling, pause_minority}
+    ] },
+    { rabbitmq_management, [ { listener, [
+            { port, 15672 },
+            { ssl, false }
+    ] } ] }
+].

--- a/k8s/rmq/service.yml
+++ b/k8s/rmq/service.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rmq
+spec:
+  ports:
+  - port: 4369
+    name: rabbitmq-epmd
+  - port: 5672
+    name: rabbitmq-main
+  - port: 15672
+    name: rabbitmq-management
+  - port: 25672
+    name: rabbitmq-management-ssl
+  clusterIP: None
+  selector:
+    app: rmq

--- a/k8s/rmq/statefulset.yml
+++ b/k8s/rmq/statefulset.yml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: rmq
+spec:
+  serviceName: rmq
+  replicas: 3
+  volumeClaimTemplates:
+  - metadata:
+      name: rmq
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      storageClassName: fast
+      resources:
+        requests:
+          storage: 1Gi
+  template:
+    metadata:
+      labels:
+        app: rmq
+    spec:
+      containers:
+      - name: rmq
+        image: rabbitmq-cluster:3.6.13
+        lifecycle:
+          preStop:
+            exec:
+              command: ["rabbitmqctl", "stop"]
+
+        livenessProbe:
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 30
+          exec:
+            command: ["rabbitmqctl", "node_health_check"]
+
+        readinessProbe:
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 1
+          failureThreshold: 10
+          exec:
+            command: ["rabbitmqctl", "node_health_check"]
+
+        ports:
+        - containerPort: 4369
+        - containerPort: 5672
+        - containerPort: 15672
+        - containerPort: 25672
+
+        volumeMounts:
+          - mountPath: /var/lib/rabbitmq
+            name: rmq
+
+        env:
+          - name: CLUSTERED
+            value: "true"
+          - name: CLUSTER_WITH
+            value: "rmq-0"
+          - name: RABBITMQ_SERVICE_DOMAIN
+            value: "rmq.default.svc.cluster.local"
+          - name: RABBITMQ_USERNAME
+            value: "test"
+          - name: RABBITMQ_PASSWORD
+            value: "testpass"
+          - name: RABBITMQ_VHOST
+            value: "/"
+          - name: RABBITMQ_VHOST
+            value: "/"
+          - name: RABBITMQ_ERLANG_COOKIE
+            value: "584ee2e9-99ba-4736-9e4d-f12273f171c6"
+      - name: fwd
+        image: rmqfwd:latest
+        imagePullPolicy: IfNotPresent
+        args: 
+        - "trace" 
+        - "--es-major-version"
+        - "6" 
+        - "--rmq-creds"
+        - "test:testpass" 
+        - "--rmq-host"
+        - "rmq-0.rmq.default.svc.cluster.local" 
+        - "--es-base-url"
+        - "http://elasticsearch-0.es.default.svc.cluster.local:9200"
+        env:
+          - name: RUST_LOG
+            value: "rmqfwd=DEBUG"
+          - name: RUST_BACKTRACE
+            value: "1"
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast
+provisioner: k8s.io/minikube-hostpath
+parameters:
+  type: pd-ssd

--- a/src/rmq.rs
+++ b/src/rmq.rs
@@ -11,7 +11,6 @@ use crate::lapin::types::*;
 use chrono::prelude::*;
 use failure::Error;
 use futures::future::Future;
-use futures::future::{loop_fn, Loop};
 use futures::sync::mpsc::Sender;
 use futures::{future, IntoFuture, Sink, Stream};
 use opt::RmqConfig as Config;
@@ -21,8 +20,7 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use std::str;
 use std::str::FromStr;
 use tokio;
-use tokio::net::{ConnectFuture, TcpStream};
-use tokio::timer::Delay;
+use tokio::net::TcpStream;
 
 const REPLAYED_HEADER: &str = "X-Replayed";
 
@@ -304,7 +302,7 @@ fn tcp_connection(
                             attempts
                         );
                         use std::time::Duration;
-                        let wait_time = Duration::from_secs(1 * (attempts as u64));
+                        let wait_time = Duration::from_secs(u64::from(attempts));
                         std::thread::sleep(wait_time);
                         tcp_connection(address, opts2, attempts + 1)
                     }


### PR DESCRIPTION
This simplifies scenarios where `rmqfwd` is started concurrently to rabbit itself (e.g. when deploying a statefullset in kubernetes).